### PR TITLE
Bump Garak dependency to 0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A lightweight MCP (Model Context Protocol) server for Garak.
 
+Tested with **Garak 0.12**.
+
 Example:
 
 https://github.com/user-attachments/assets/f6095d26-2b79-4ef7-a889-fd6be27bbbda

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 dependencies = [
     "mcp[cli]>=1.3.0",
     "requests (>=2.32.3,<3.0.0)",
-    "garak (>=0.10.3.1,<0.11.0.0)",
+    "garak (>=0.12,<0.13)",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- update Garak dependency to 0.12
- document the new Garak version in the README

